### PR TITLE
Provide COM_INTERFACE macro to support COM interop

### DIFF
--- a/src/comptr.rs
+++ b/src/comptr.rs
@@ -29,7 +29,7 @@ impl<Vtbl> Clone for ComAbi<Vtbl> {
 /// Smart pointer for Windows Runtime objects. This pointer automatically maintains the
 /// reference count of the underlying COM object.
 #[repr(transparent)]
-pub(crate) struct ComPtr<T: ComInterfaceAbi>(ptr::NonNull<T>);
+pub struct ComPtr<T: ComInterfaceAbi>(ptr::NonNull<T>);
 
 pub(crate) trait ComPtrHelpers {
     /// Changes the type of the underlying COM object to a different interface without doing `QueryInterface`.
@@ -69,7 +69,7 @@ impl<T: ComInterfaceAbi> ComPtr<T> {
     }
 
     #[inline]
-    pub(crate) fn as_abi(&self) -> &T {
+    pub fn as_abi(&self) -> &T {
         unsafe { self.0.as_ref() }
     }
 }

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -1,0 +1,84 @@
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! COM_INTERFACE {
+    // version with no methods
+    ($(#[$attr:meta])* interface $interface:ident ($vtbl:ident) : $pinterface:ident [$iid:ident]
+        {}
+    ) => {
+        #[repr(transparent)] #[allow(missing_copy_implementations)] #[doc(hidden)]
+        pub struct $vtbl {
+            pub parent: <<$pinterface as $crate::ComInterface>::TAbi as $crate::ComInterfaceAbi>::Vtbl
+        }
+        $(#[$attr])* #[repr(transparent)] #[derive(Clone)]
+        pub struct $interface($crate::ComPtr<$crate::ComAbi<$vtbl>>);
+        impl $crate::ComIid for $interface {
+            #[inline] fn iid() -> &'static crate::Guid { &$iid }
+        }
+        impl $crate::ComInterface for $interface {
+            type TAbi = $crate::ComAbi<$vtbl>;
+            #[inline] unsafe fn wrap_com(ptr: *mut Self::TAbi) -> Self { $interface($crate::ComPtr::wrap(ptr)) }
+            #[inline] fn get_abi(&self) -> &Self::TAbi { self.0.as_abi() }
+        }
+        impl std::ops::Deref for $interface {
+            type Target = $crate::$pinterface;
+            #[inline]
+            fn deref(&self) -> &$crate::$pinterface {
+                unsafe { std::mem::transmute(self) }
+            }
+        }
+        impl std::ops::DerefMut for $interface {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut $crate::$pinterface {
+                unsafe { std::mem::transmute(self) }
+            }
+        }
+    };
+
+    // version with methods
+    ($(#[$attr:meta])* interface $interface:ident ($vtbl:ident) : $pinterface:ident [$iid:ident]
+        {$(
+            $(#[cfg($cond_attr:meta)])* fn $method:ident(&mut self $(,$p:ident : $t:ty)*) -> $rtr:ty
+        ),+}
+    ) => {
+        #[repr(C)] #[allow(missing_copy_implementations)] #[doc(hidden)]
+        pub struct $vtbl {
+            pub parent: <<$pinterface as $crate::ComInterface>::TAbi as $crate::ComInterfaceAbi>::Vtbl
+            $(, $(#[cfg($cond_attr)])* pub $method: unsafe extern "system" fn(
+                This: *mut $interface
+                $(,$p: $t)*
+            ) -> $rtr)+
+        }
+        $(#[$attr])* #[repr(transparent)] #[derive(Clone)]
+        pub struct $interface($crate::ComPtr<$crate::ComAbi<$vtbl>>);
+        impl $interface {
+            #[inline]
+            $(pub unsafe fn $method(&mut self $(,$p: $t)*) -> $rtr {
+                let abi = $crate::ComInterface::get_abi(&*self);
+                ((*$crate::ComInterfaceAbi::get_vtbl(&*abi)).$method)(
+                    abi as *const _ as *mut _ $(,$p)*
+                )
+            })+
+        }
+        impl $crate::ComIid for $interface {
+            #[inline] fn iid() -> &'static crate::Guid { &$iid }
+        }
+        impl $crate::ComInterface for $interface {
+            type TAbi = $crate::ComAbi<$vtbl>;
+            #[inline] unsafe fn wrap_com(ptr: *mut Self::TAbi) -> Self { $interface($crate::ComPtr::wrap(ptr)) }
+            #[inline] fn get_abi(&self) -> &Self::TAbi { self.0.as_abi() }
+        }
+        impl std::ops::Deref for $interface {
+            type Target = $crate::$pinterface;
+            #[inline]
+            fn deref(&self) -> &$crate::$pinterface {
+                unsafe { std::mem::transmute(self) }
+            }
+        }
+        impl std::ops::DerefMut for $interface {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut $crate::$pinterface {
+                unsafe { std::mem::transmute(self) }
+            }
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub use guid::Guid;
 pub type TrustLevel = w::winrt::inspectable::TrustLevel;
 
 // Compared to the DEFINE_GUID macro from winapi, this one creates a private const
+#[macro_export]
 macro_rules! DEFINE_IID {
     (
         $name:ident, $l:expr, $w1:expr, $w2:expr, $b1:expr, $b2:expr, $b3:expr, $b4:expr, $b5:expr,
@@ -57,11 +58,12 @@ mod bstr;
 pub use bstr::BStr;
 
 mod comptr;
-pub(crate) use comptr::ComPtr;
-pub use comptr::ComArray;
+pub use comptr::{ComPtr, ComArray, ComAbi};
 
 mod cominterfaces;
 pub use cominterfaces::{ComInterface, ComInterfaceAbi, ComIid, IUnknown, IRestrictedErrorInfo, IAgileObject};
+
+pub mod interop;
 
 mod rt;
 pub use rt::{RtInterface, RtClassInterface, RtNamedClass, RtValueType, RtType, RtActivatable,


### PR DESCRIPTION
This implements the macro for "classic" COM interop as discussed in #80.

The implementation of the macro mostly closely mirrors `RT_INTERFACE!`; I started with a copy of that macro, removed support for WinRT-specific features (generics, statics, `IInspectable` special case) and `Rt*` trait impls, then added the method impls directly in the macro expansion since we can't rely on generated code here. The other major difference for the user is that those method impls are all marked `unsafe` and expose an unrefined direct translation of the ABI with raw pointers, exposed `HRESULT`s, out pointers for returns, PascalCasing, etc.. The idea is that our COM interop support is intended to be purely a low-level FFI rather than a higher-level "projection," reflecting that projections are mostly a WinRT-specific concept.

**Naming/structure**: I considered a more precise name like `COMBASE_INTERFACE`, `COM_INTEROP_INTERFACE`, etc., but decided on plain `COM_INTERFACE` even though com_rs exposes a similar macro with the same name. This was based on my guess that few projects would ever want to use more than one COM macro, and any that did could qualify with `winrt::COM_INTERFACE`, which seems like a good name that reflects our macro's purpose and focus: a COM interface macro designed for interop with WinRT. It's in a new file called interop.rs because I felt COM interop support is a specialized feature that should be clearly labeled and delineated from other features. (I was thinking in the future this might expand into an `interop` folder, especially if we start adding direct support for individual COM interop interfaces)

**Dependencies**: I'm not a Rust macro expert but my understanding is that all the identifiers referenced from a macro expansion need to be accessible at the point of macro invocation. This unfortunately means that to get this macro to work from outside the crate I had to publically export `ComPtr`, `ComAbi`, and `as_abi()`; since using the new macro requires defining an IID I exposed `DEFINE_IID!` with `macro_export` as well. 

It seems to me that it would be nice if there were a way for crates to better encapsulate implementation details of exported macros - so that macros could better fit into proper API design. I started a Reddit thread asking about this (where I threw out the off-the-cuff idea of providing a `pub(crate_macros)` accessibility option for this) but it didn't draw any interest. https://www.reddit.com/r/rust/comments/cg6bln/encapsulating_implementation_details_of_exported/

**Testing**: I ported my example to use this branch and this macro, and it works (On My Machine). Unfortunately this example isn't quite ready to be published or added to the `winrt-rust` `examples` folder because I'm not quite done disentangling its dependencies. If you feel you need to see a working test case for yourself before merging it'll probably be another week or two before I can provide it. 😟

As you can see, I went back and forth on some of these decisions, so please let me know if you have disagreements or concerns. Thanks!